### PR TITLE
fix: correct package name in release-plz.toml configuration

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,9 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 """
 
-# Package-specific configuration for turbo-cdn
+# Package-specific configuration for py2pyd
 [[package]]
-name = "turbo-cdn"
+name = "py2pyd"
 # Enable changelog updates
 changelog_update = true
 # Enable GitHub releases for the main package


### PR DESCRIPTION
## 🐛 Fix Release-plz Configuration Error

This PR fixes a critical configuration error in `release-plz.toml` that was preventing proper release automation.

### 🔧 Problem

The `release-plz.toml` file was incorrectly configured with:
```toml
[[package]]
name = "turbo-cdn"  # ❌ Wrong package name
```

This caused release-plz to fail because it was looking for a package named "turbo-cdn" instead of the actual package "py2pyd".

### ✅ Solution

Corrected the configuration to:
```toml
[[package]]
name = "py2pyd"  # ✅ Correct package name
```

### 📋 Changes Made

- **Fixed package name**: Changed from `turbo-cdn` to `py2pyd` in release-plz.toml
- **Maintained all other settings**: Version management, changelog generation, and GitHub releases remain unchanged

### 🔍 Context

- `turbo-cdn` is correctly used as a **dependency** in Cargo.toml (version 0.4.1)
- The main **package name** should be `py2pyd` as defined in Cargo.toml
- This fix will allow release-plz to properly:
  - Generate changelogs
  - Create version tags
  - Publish GitHub releases
  - Manage semantic versioning

### 🧪 Testing

After merging this PR, release-plz should:
- ✅ Successfully detect the py2pyd package
- ✅ Generate proper version bumps
- ✅ Create GitHub releases with correct tags
- ✅ Update CHANGELOG.md automatically

### 🚀 Impact

This fix will restore the automated release workflow and ensure proper version management for the py2pyd project.