### PR TITLE
fix: resolve macOS cross-compilation issues in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,29 +10,48 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-    container: ghcr.io/loonghao/rust-toolkit:cross-compile
     strategy:
       matrix:
-        target:
-          # Zero-dependency Windows builds
-          - x86_64-pc-windows-gnu
-          - i686-pc-windows-gnu
-          # Static Linux builds
-          - x86_64-unknown-linux-musl
-          - aarch64-unknown-linux-musl
-          # Standard builds
-          - x86_64-unknown-linux-gnu
-          - aarch64-unknown-linux-gnu
-          - x86_64-apple-darwin
-          - aarch64-apple-darwin
+        include:
+          # Linux builds using Docker container
+          - target: x86_64-pc-windows-gnu
+            os: ubuntu-latest
+            container: ghcr.io/loonghao/rust-toolkit:cross-compile
+          - target: i686-pc-windows-gnu
+            os: ubuntu-latest
+            container: ghcr.io/loonghao/rust-toolkit:cross-compile
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            container: ghcr.io/loonghao/rust-toolkit:cross-compile
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            container: ghcr.io/loonghao/rust-toolkit:cross-compile
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            container: ghcr.io/loonghao/rust-toolkit:cross-compile
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            container: ghcr.io/loonghao/rust-toolkit:cross-compile
+          # macOS builds using native macOS runner
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain (macOS only)
+        if: matrix.os == 'macos-latest'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
       - name: Check Rust version
         shell: bash
         run: |
-          echo "🦀 Checking Rust version in Docker container..."
+          echo "🦀 Checking Rust version..."
           rustc --version
           echo "📦 Cargo version:"
           cargo --version
@@ -42,10 +61,12 @@ jobs:
         run: |
           echo "🚀 Building release binary for ${{ matrix.target }}"
 
-          # Set environment for zero-dependency builds
-          export RUSTFLAGS="-C target-feature=+crt-static"
-          export OPENSSL_STATIC=1
-          export PKG_CONFIG_ALLOW_CROSS=1
+          # Set environment for zero-dependency builds (Linux/Windows only)
+          if [[ "${{ matrix.os }}" != "macos-latest" ]]; then
+            export RUSTFLAGS="-C target-feature=+crt-static"
+            export OPENSSL_STATIC=1
+            export PKG_CONFIG_ALLOW_CROSS=1
+          fi
 
           # Build the binary
           cargo build --release --target ${{ matrix.target }}


### PR DESCRIPTION
## 🐛 Fix macOS Cross-Compilation Build Failures

This PR resolves the macOS build failures in the release workflow caused by attempting to cross-compile macOS targets from Linux Docker containers.

### 🔧 Problem

The release workflow was failing for macOS targets with errors like:
```
cargo:warning=cc: error: unrecognized command-line option '-arch'
cargo:warning=cc: error: unrecognized command-line option '-mmacosx-version-min=11.0'
```

This happened because:
- Linux Docker containers were used for **all** targets including macOS
- Linux `cc` compiler doesn't support macOS-specific compilation flags
- The `ring` crate requires native compilation tools for macOS targets

### ✅ Solution

**Use platform-specific runners**:
- 🐧 **Linux Docker containers** for Linux/Windows cross-compilation
- 🍎 **Native macOS runners** for macOS targets

### 📋 Changes Made

1. **Matrix Strategy Update**:
   ```yaml
   strategy:
     matrix:
       include:
         # Linux builds using Docker container
         - target: x86_64-pc-windows-gnu
           os: ubuntu-latest
           container: ghcr.io/loonghao/rust-toolkit:cross-compile
         # macOS builds using native macOS runner
         - target: x86_64-apple-darwin
           os: macos-latest
         - target: aarch64-apple-darwin
           os: macos-latest
   ```

2. **Conditional Rust Installation**:
   - Install Rust toolchain only for macOS runners
   - Docker containers already have Rust pre-installed

3. **Environment Variables**:
   - Remove incompatible flags for macOS builds:
     - `RUSTFLAGS="-C target-feature=+crt-static"` (Linux/Windows only)
     - `OPENSSL_STATIC=1` (not needed for macOS)
     - `PKG_CONFIG_ALLOW_CROSS=1` (cross-compilation specific)

### 📊 Build Matrix

| Target | OS | Container | Notes |
|--------|----|-----------| ----- |
| `x86_64-pc-windows-gnu` | ubuntu-latest | ✅ Docker | Cross-compile |
| `i686-pc-windows-gnu` | ubuntu-latest | ✅ Docker | Cross-compile |
| `x86_64-unknown-linux-musl` | ubuntu-latest | ✅ Docker | Static build |
| `aarch64-unknown-linux-musl` | ubuntu-latest | ✅ Docker | Cross-compile |
| `x86_64-unknown-linux-gnu` | ubuntu-latest | ✅ Docker | Native |
| `aarch64-unknown-linux-gnu` | ubuntu-latest | ✅ Docker | Cross-compile |
| `x86_64-apple-darwin` | macos-latest | ❌ Native | 🍎 Intel Mac |
| `aarch64-apple-darwin` | macos-latest | ❌ Native | 🍎 Apple Silicon |

### 🧪 Testing

This fix should resolve:
- ✅ `ring` crate compilation errors on macOS
- ✅ `x86_64-apple-darwin` build failures
- ✅ `aarch64-apple-darwin` build failures
- ✅ Maintain existing Linux/Windows cross-compilation

### 🚀 Benefits

- **Reliability**: Native compilation for macOS targets
- **Performance**: Faster macOS builds (no emulation)
- **Compatibility**: Proper handling of platform-specific dependencies
- **Maintainability**: Clear separation of build environments

### 📝 Technical Details

The `ring` crate (used by `reqwest` → `turbo-cdn`) requires:
- Native C compiler for cryptographic operations
- Platform-specific assembly optimizations
- Proper target architecture support

Linux containers cannot provide macOS-specific compilation tools, hence the need for native macOS runners.