### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/loonghao/py2pyd/compare/v0.1.1...v0.1.2) - 2025-06-27
+
+### Fixed
+
+- resolve macOS cross-compilation issues in release workflow
+- correct package name in release-plz.toml configuration
+
+### Other
+
+- release v0.1.1
+
 ## [0.1.1](https://github.com/loonghao/py2pyd/releases/tag/v0.1.1) - 2025-06-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "py2pyd"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py2pyd"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["longhao <hal.long@outlook.com>"]
 description = "A Rust-based tool to compile Python modules to pyd files"


### PR DESCRIPTION



## 🤖 New release

* `py2pyd`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/loonghao/py2pyd/compare/v0.1.1...v0.1.2) - 2025-06-27

### Fixed

- resolve macOS cross-compilation issues in release workflow
- correct package name in release-plz.toml configuration

### Other

- release v0.1.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).