### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/loonghao/py2pyd/compare/v0.1.5...v0.1.6) - 2026-01-07
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.5](https://github.com/loonghao/py2pyd/compare/v0.1.4...v0.1.5) - 2025-12-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "py2pyd"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py2pyd"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["longhao <hal.long@outlook.com>"]
 description = "A Rust-based tool to compile Python modules to pyd files"


### PR DESCRIPTION



## 🤖 New release

* `py2pyd`: 0.1.5 -> 0.1.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/loonghao/py2pyd/compare/v0.1.5...v0.1.6) - 2026-01-07

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).